### PR TITLE
Update operator chart version and clusterrole rules

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.1"
+appVersion: "0.14.2"

--- a/charts/operator/templates/010-clusterrole.yaml
+++ b/charts/operator/templates/010-clusterrole.yaml
@@ -28,6 +28,8 @@ rules:
   - secrets
     # The cluster operator needs to access and manage persistent volume claims to bind them to Kaspr components for persistent data
   - persistentvolumeclaims
+    # The cluster operator needs to access and manage pods/exec to run commands inside Kaspr component pods 
+  - pods/exec
   verbs:
   - get
   - list
@@ -36,9 +38,6 @@ rules:
   - delete
   - patch
   - update
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]  
 - apiGroups:
   - "apps"
   resources:

--- a/charts/operator/templates/015-clusterrole.yaml
+++ b/charts/operator/templates/015-clusterrole.yaml
@@ -32,10 +32,6 @@ rules:
   - watch
   - list
 
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["create"]  
-
 - apiGroups:
   - "kaspr.io"
   resources:


### PR DESCRIPTION
This pull request updates the Helm chart for the Kaspr operator, primarily to grant the operator permissions to execute commands inside pods and to bump the chart and application versions. The changes ensure the operator has the necessary RBAC permissions for pod exec operations and maintain version consistency.

**RBAC permissions update:**

* Added `pods/exec` to the list of resources in the ClusterRole, allowing the operator to run commands inside Kaspr component pods.
* Removed a redundant rule block that separately granted `create` permission for `pods/exec`, consolidating permissions for clarity and maintainability. [[1]](diffhunk://#diff-a24546ddd46a83ebf5b61dcd82af0bc691116d4a5bc8655dc725b4c02bbd0494L39-L41) [[2]](diffhunk://#diff-080bfff316c32f59bef3f71c5c9f5e76ba2a14de5a785c11a51830910e02dc6dL35-L38)

**Version updates:**

* Bumped the chart version in `Chart.yaml` from `0.8.1` to `0.8.2` and the application version from `0.14.1` to `0.14.2` to reflect the new changes.