### PR TITLE
Update Operator v0.17.1 (Chart v0.10.1)

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.17.0"
+appVersion: "0.17.1"

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.3
+version: 0.10.0
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.16.2"
+appVersion: "0.17.0"

--- a/charts/operator/crds/kasprjoin.crd.yaml
+++ b/charts/operator/crds/kasprjoin.crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kasprjoins.kaspr.io
+spec:
+  scope: Namespaced
+  group: kaspr.io
+  names:
+    kind: KasprJoin
+    plural: kasprjoins
+    singular: kasprjoin
+    shortNames:
+      - kjoin
+      - kj
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                name:
+                  type: string
+                  description: The name of the key join.
+                description:
+                  type: string
+                  description: A short description of what this key join does.
+                leftTable:
+                  type: string
+                  description: >
+                    Name of the left-side KasprTable resource.
+                    This is the "driving" table whose changes trigger key extraction.
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                rightTable:
+                  type: string
+                  description: >
+                    Name of the right-side KasprTable resource (the "lookup" table).
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                extractor:
+                  type: object
+                  description: >
+                    Python function that extracts the join key from left-table values.
+                    The returned value is used to look up the corresponding record
+                    in the right table.
+                  properties:
+                    entrypoint:
+                      type: string
+                      description: Name of the function to run.
+                    python:
+                      type: string
+                      description: Python code defining the extractor function.
+                  required:
+                    - python
+                type:
+                  type: string
+                  description: >
+                    Join semantics. "inner" skips emission when right side is None.
+                    "left" emits JoinedValue with right=None when no match exists.
+                  enum: ["inner", "left"]
+                  default: "inner"
+                outputChannel:
+                  type: string
+                  description: >
+                    Name of the output channel for joined results.
+                    KasprAgents reference this via input.channel.name.
+                    Defaults to "{name}-channel" if not specified.
+              required:
+                - leftTable
+                - rightTable
+                - extractor
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/charts/operator/templates/015-clusterrole.yaml
+++ b/charts/operator/templates/015-clusterrole.yaml
@@ -48,6 +48,7 @@ rules:
   - kasprwebviews
   - kasprtables
   - kasprtasks
+  - kasprjoins
   verbs:
   - get
   - list
@@ -66,6 +67,7 @@ rules:
   - kasprwebviews/status
   - kasprtables/status
   - kasprtasks/status
+  - kasprjoins/status
   verbs:
   - get
   - patch

--- a/charts/resources/Chart.yaml
+++ b/charts/resources/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart, its templates or underlying CRDs.
-version: 2.1.0
+version: 2.2.0

--- a/charts/resources/templates/joins.yaml
+++ b/charts/resources/templates/joins.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.joins }}
+{{- $root := . -}}
+{{- range .Values.joins }}
+---
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: {{ .name }}
+spec:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/resources/values.yaml
+++ b/charts/resources/values.yaml
@@ -59,8 +59,8 @@ apps:
     # when the app is un-deployed.
     deleteClaim: True
 
-# TODO
 agents: []
 tables: []
 tasks: []
-webviews: []    
+webviews: []
+joins: []


### PR DESCRIPTION
This pull request introduces support for a new `KasprJoin` custom resource, enabling users to define and manage join operations between tables in the Kaspr ecosystem. The changes include the creation of the `KasprJoin` CRD, updates to Helm charts to support the new resource, and the necessary permissions for the operator to manage `KasprJoin` objects.

**KasprJoin CRD and Helm Chart Integration:**

* Added a new `KasprJoin` CustomResourceDefinition (`kasprjoin.crd.yaml`), allowing users to declare join operations between tables, including extractor functions and join types.
* Updated the `operator` Helm chart version and application version to reflect the addition of the new resource.
* Modified the operator's ClusterRole to grant permissions for `kasprjoins` and `kasprjoins/status` resources, ensuring the operator can manage and update join objects. [[1]](diffhunk://#diff-080bfff316c32f59bef3f71c5c9f5e76ba2a14de5a785c11a51830910e02dc6dR51) [[2]](diffhunk://#diff-080bfff316c32f59bef3f71c5c9f5e76ba2a14de5a785c11a51830910e02dc6dR70)

**Helm Chart Template and Values Support:**

* Added a Helm template (`joins.yaml`) to render `KasprJoin` resources based on user-provided values, making it easy to manage joins declaratively.
* Updated `values.yaml` to include a `joins` array, allowing users to specify joins in their Helm values.
* Incremented the `resources` Helm chart version to indicate the new feature.