### PR TITLE
Bump operator chart versions and add registry env

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -7,10 +7,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the kaspr-operator being deployed. This version number should be
 # incremented whenever there's a new version of kaspr-operator. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.17.1"
+appVersion: "0.17.3"

--- a/charts/operator/templates/030-deployment.yaml
+++ b/charts/operator/templates/030-deployment.yaml
@@ -89,6 +89,10 @@ spec:
             - name: HUNG_REBALANCING_THRESHOLD_SECONDS
               value: "{{ .Values.operator.env.hungRebalancingThresholdSeconds }}"
             {{- end }}
+            {{- if .Values.operator.env.kasprImageRegistry }}
+            - name: KASPR_IMAGE_REGISTRY
+              value: "{{ .Values.operator.env.kasprImageRegistry }}"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.operator.service.port }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -78,6 +78,9 @@ operator:
     hungMemberDetectionEnabled: ""
     # Time threshold in seconds before a rebalancing member is considered hung (default: 300)
     hungRebalancingThresholdSeconds: ""
+    # Custom container image registry for Kaspr application images (default: Docker Hub)
+    # e.g. "myregistry.azurecr.io" will prefix all kaspr app images with this registry
+    kasprImageRegistry: ""
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This pull request updates the Helm chart for the `kaspr-operator` with a new version, introduces support for specifying a custom image registry for Kaspr application images, and exposes this configuration through the chart's values. These changes make it easier to deploy Kaspr from private or custom registries.

Key changes:

**Version Updates**
- Bumped the Helm chart version to `0.10.2` and the `kaspr-operator` application version to `0.17.3` in `Chart.yaml` to reflect the latest release.

**Custom Image Registry Support**
- Added a new `kasprImageRegistry` environment variable to the deployment manifest, allowing the operator to use a custom container registry for Kaspr images if specified.
- Exposed the `kasprImageRegistry` setting in `values.yaml` with documentation, enabling users to configure the image registry via Helm values.